### PR TITLE
Optional custom rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,29 @@ export default function (config) {
 }
 ```
 
+### Options
+
+#### Custom redirects
+
+In addition to the generated redirects, you may want to supply your
+own rewrite rules. In this case, you can pass array of custom redirects to the plugin, such as
+```js
+export default function(config) {
+    netlifyPlugin(config, {
+        redirects: [
+          '/api/* https://api.example.com/:splat 200',
+          '/custom/* https://custom.example.com/ 200'
+        ]
+    });
+}
+```
+which generates the following `_redirects` file:
+```
+/api/* https://api.example.com/:splat 200
+/custom/* https://custom.example.com/ 200
+/* /index.html 200
+```
+
 ## Generated files
 
 This plugin genererates `_headers` and `_redirects` files inside build folder

--- a/index.js
+++ b/index.js
@@ -5,7 +5,16 @@
 
 class NetlifyServerPushPlugin {
   constructor({ redirects }) {
-    this.redirects = Array.isArray(redirects) ? redirects : [];
+    this.redirects = [];
+    if (redirects !== undefined) {
+      if (Array.isArray(redirects)) {
+        this.redirects = redirects;
+      } else {
+        throw new TypeError(
+          `redirects should be an array, but was of type '${typeof redirects}'`,
+        );
+      }
+    }
   }
 
   apply(compiler) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@
  */
 
 class NetlifyServerPushPlugin {
+  constructor({ redirects }) {
+    this.redirects = Array.isArray(redirects) ? redirects : [];
+  }
+
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
       const routes = [];
@@ -26,7 +30,7 @@ class NetlifyServerPushPlugin {
       let headers =
         '/*\n\tCache-Control: public, max-age=3600, no-cache\n\tAccess-Control-Max-Age: 600\n/sw.js\n\tCache-Control: private, no-cache\n/*.chunk.*.js\n\tCache-Control: public, max-age=31536000';
 
-      const redirects = `/* /index.html 200`;
+      const redirects = `${this.redirects.join('\n')}\n/* /index.html 200`;
 
       routes.forEach(filename => {
         const path = filename
@@ -34,7 +38,9 @@ class NetlifyServerPushPlugin {
           .replace(/\.chunk(\.\w+)?\.js$/, '')
           .replace(/\/home/, '/');
         const routeJs = `Link: </${filename}>; rel=preload; as=script`;
-        headers = `${headers}\n${path}\n\t${mainCss}\n\t${mainJs}\n\t${routeJs}`;
+        headers = `${headers}\n${path}\n\t${mainCss}\n\t${mainJs}\n\t${
+          routeJs
+        }`;
       });
 
       compilation.assets._headers = {
@@ -60,11 +66,13 @@ class NetlifyServerPushPlugin {
   }
 }
 
-module.exports = function(config) {
+module.exports = function(config, options = {}) {
   if (!config || !config.plugins) {
-    throw new Error('You need to pass the webpack config to preact-cli-plugin-netlify!');
+    throw new Error(
+      'You need to pass the webpack config to preact-cli-plugin-netlify!',
+    );
   }
-  config.plugins.push(new NetlifyServerPushPlugin());
+  config.plugins.push(new NetlifyServerPushPlugin(options));
   const plugins = config.plugins;
   for (let pluginIndex = 0; pluginIndex < plugins.length; pluginIndex++) {
     const plugin = plugins[pluginIndex];


### PR DESCRIPTION
Hey 👋

This adds the possibility to pass an array of custom rewrites to the plugin. A use case for this would be the example from the [netlify docs](https://www.netlify.com/docs/redirects/#proxying) on **Proxying**:
```js
export default function(config) {
    netlifyPlugin(config, {
        redirects: ['/api/* https://api.example.com/:splat 200']
    });
}
```
becomes
```
/api/* https://api.example.com/:splat 200
/* /index.html 200
```