### PR TITLE
Reading from cli's push manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,6 @@ class NetlifyServerPushPlugin {
   apply(compiler) {
     const handler = (compilation, callback) => {
       const routes = [];
-      // Set default value as comment incase if this file is not present
-      let mainJs = '# no js files';
-      let mainCss = '# no css files';
-
-      const hasEsm =
-        Object.keys(compilation.assets).filter(filename =>
-          /\.esm\.js$/.test(filename)
-        ).length !== 0;
 
       let manifest = compilation.assets['push-manifest.json'];
       if (!manifest) {
@@ -38,20 +30,6 @@ class NetlifyServerPushPlugin {
       }
       manifest = JSON.parse(manifest.source());
 
-      for (const filename in compilation.assets) {
-        if (!/\.map$/.test(filename)) {
-          if (/route-/.test(filename)) {
-            routes.push(filename);
-          } else if (/^(style|bundle)(.+)\.css$/.test(filename)) {
-            mainCss = `Link: </${filename}>; rel=preload; as=style`;
-          } else if (hasEsm && /^bundle(.+)\.esm\.js$/.test(filename)) {
-            mainJs = `Link: </${filename}>; rel=preload; as=script; crossorigin=anonymous`;
-          } else if (!hasEsm && /^bundle(.+)\.js$/.test(filename)) {
-            mainJs = `Link: </${filename}>; rel=preload; as=script`;
-          }
-        }
-      }
-
       let headers =
         '/*\n\tCache-Control: public, max-age=3600, no-cache\n\tAccess-Control-Max-Age: 600\n/sw.js\n\tCache-Control: private, no-cache\n/*.chunk.*.js\n\tCache-Control: public, max-age=31536000';
 
@@ -60,10 +38,6 @@ class NetlifyServerPushPlugin {
       }
 
       const redirects = `${this.redirects.join('\n')}\n/* /index.html 200`;
-
-      if (routes.length === 0) {
-        headers += `\n/*\n\t${mainCss}\n\t${mainJs}`;
-      }
 
       for(const route in manifest) {
         const files = Object.keys(manifest[route]);

--- a/index.js
+++ b/index.js
@@ -45,6 +45,9 @@ class NetlifyServerPushPlugin {
         files.forEach(file => {
           const details = manifest[route][file];
           routePreloadText += `\n\tLink: </${file}>; rel=preload; as=${details.type}`
+          if (/^bundle(.+)\.esm\.js$/.test(filename)) {
+            routePreloadText += '; crossorigin=anonymous';
+          }
         })
         headers = `${headers}\n${routePreloadText}`;
       }

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ class NetlifyServerPushPlugin {
 
       let manifest = compilation.assets['push-manifest.json'];
       if (!manifest) {
+        // on pre-render build this is not present and thus need an early exit
         callback();
         return;
       }

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class NetlifyServerPushPlugin {
         return;
       }
       manifest = JSON.parse(manifest.source());
-      console.log({manifest});
+
       for (const filename in compilation.assets) {
         if (!/\.map$/.test(filename)) {
           if (/route-/.test(filename)) {
@@ -73,17 +73,6 @@ class NetlifyServerPushPlugin {
         })
         headers = `${headers}\n${routePreloadText}`;
       }
-
-
-
-      // routes.forEach(filename => {
-      //   const path = filename
-      //     .replace(/route-/, '/')
-      //     .replace(/\.chunk(\.\w+)?\.js$/, '')
-      //     .replace(/\/home/, '/');
-      //   const routeJs = `Link: </${filename}>; rel=preload; as=script`;
-      //   headers = `${headers}\n${path}\n\t${mainCss}\n\t${mainJs}\n\t${routeJs}`;
-      // });
 
       compilation.assets._headers = {
         source() {


### PR DESCRIPTION
This changes from constructing the preload manifest ourselves to deferring it to what CLI generates.

**Diff**
Before:
```
/*
	Cache-Control: public, max-age=3600, no-cache
	Access-Control-Max-Age: 600
/sw.js
	Cache-Control: private, no-cache
/*.chunk.*.js
	Cache-Control: public, max-age=31536000
/blog.chunk.443ff.css
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-blog.chunk.443ff.css>; rel=preload; as=script
/blog.chunk.ebdc3.esm.js
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-blog.chunk.ebdc3.esm.js>; rel=preload; as=script
/.chunk.26439.css
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-home.chunk.26439.css>; rel=preload; as=script
/.chunk.9296d.esm.js
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-home.chunk.9296d.esm.js>; rel=preload; as=script
/photographs.chunk.96904.css
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-photographs.chunk.96904.css>; rel=preload; as=script
/photographs.chunk.7c15c.esm.js
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-photographs.chunk.7c15c.esm.js>; rel=preload; as=script
/blog
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-blog.chunk.a031c.js>; rel=preload; as=script
/
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-home.chunk.dd9f0.js>; rel=preload; as=script
/photographs
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script; crossorigin=anonymous
	Link: </route-photographs.chunk.ffd95.js>; rel=preload; as=script
```


After: 
```
/*
	Cache-Control: public, max-age=3600, no-cache
	Access-Control-Max-Age: 600
/sw.js
	Cache-Control: private, no-cache
/*.chunk.*.js
	Cache-Control: public, max-age=31536000
/
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script
	Link: </route-home.chunk.9296d.esm.js>; rel=preload; as=script
	Link: </route-home.chunk.26439.css>; rel=preload; as=style
/blog
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script
	Link: </route-blog.chunk.ebdc3.esm.js>; rel=preload; as=script
	Link: </route-blog.chunk.443ff.css>; rel=preload; as=style
/photographs
	Link: </bundle.4ab52.css>; rel=preload; as=style
	Link: </bundle.fd4ad.esm.js>; rel=preload; as=script
	Link: </route-photographs.chunk.7c15c.esm.js>; rel=preload; as=script
	Link: </route-photographs.chunk.96904.css>; rel=preload; as=style
```


No errornous preloads to every javascript/css file and correct preloads to the links